### PR TITLE
Update device card color

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -127,6 +127,12 @@ h5.card-title,
   color: var(--text-color) !important;
 }
 
+/* Device cards: keep info text visible */
+.device-card h5.card-title,
+.device-card .action-text {
+  color: var(--text-color) !important;
+}
+
 /* Outline-secondary buttons (link o button) usan var(--text-color) */
 .btn-outline-secondary,
 a.btn-outline-secondary {


### PR DESCRIPTION
## Summary
- keep device card titles and action text visible in dark theme

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685e8d639c74832793f3f40172dab368